### PR TITLE
adding pointer-events: none; to the inactive slides, so in webkit inacti...

### DIFF
--- a/demo/style.css
+++ b/demo/style.css
@@ -249,6 +249,9 @@ section.bespoke-active {
 	opacity: 1;
 	z-index: 1;
 }
+section.bespoke-inactive {
+	pointer-events: none;
+}
 
 @media only screen and (max-width: 768px) {
 	body {


### PR DESCRIPTION
Adding `pointer-events: none;` to the inactive slides, so in webkit inactive slides won't overlap interactions from the active one. 

In a presentation, if you try to select text or see title-tooltips, inactive slides overlap making this imposible, this fixes it ( this happens in Chrome ). 
