### PR TITLE
Add "main" key to package.json to make it npm installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "grunt"
   },
+  "main": "./dist/bespoke.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/markdalgleish/bespoke.js.git"


### PR DESCRIPTION
Please also consider releasing it on npm — that way those who use CommonJS bundlers like browserify would be able to use bespoke easily.
