### PR TITLE
Export bespoke when required as CJS module

### DIFF
--- a/src/bespoke.js
+++ b/src/bespoke.js
@@ -131,4 +131,7 @@
 		plugins: plugins
 	};
 
+	if ((typeof module === 'object') && module && (typeof module.exports === 'object') && module.exports) {
+		module.exports = window[moduleName];
+	}
 }('bespoke', window));


### PR DESCRIPTION
In current shape bespoke.js doesn't work well as CJS module, and it's quite surpring as it's hosted on npm.

Natural way of working with CJS (Node.js style) is to do:

``` javascript
var bespoke = require('bespoke');
var deck = bespoke.from('article', {
  // ...
});
```

This won't work as `require('bespoke')` doesn't export bespoke, it actually exports nothing which doesn't make much sense. We have to refer to global scope, which is quite dirty and may require additional lint configuration if we guard global leaks with lint tool

Currently we have to:

``` javascript
// Dirty, no CJS way:
require('bespoke');
var deck = bespoke.from('article', { // bespoke is global
  // ...
});
```

This change fixes that, without breaking _global_ behavior
